### PR TITLE
Set formatted_address on gazetteer-resolved locations

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -91,6 +91,7 @@ class Location < ApplicationRecord
         location.latitude = street.latitude
         location.longitude = street.longitude
         location.place_id = "gazetteer:#{street.street_key}"
+        location.formatted_address = street.formatted_address
       end
     end
   end

--- a/app/models/street.rb
+++ b/app/models/street.rb
@@ -49,6 +49,15 @@ class Street < ApplicationRecord
     name&.downcase&.gsub(/[^[:alnum:]]+/, ' ')&.strip
   end
 
+  # Street-level address composed from the register's own fields, e.g.
+  # "Bergedorfer Straße, 21029 Bergedorf". Used in place of a Google Maps
+  # +formatted_address+ for gazetteer-resolved locations. Degrades gracefully
+  # when postal_code or stadtteil are missing.
+  def formatted_address
+    locality = [postal_code, stadtteil].compact_blank.join(' ')
+    [name, locality].compact_blank.join(', ')
+  end
+
   private
 
   def normalize_name

--- a/db/migrate/20260707130000_backfill_gazetteer_formatted_addresses.rb
+++ b/db/migrate/20260707130000_backfill_gazetteer_formatted_addresses.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Gazetteer-resolved locations were created without a formatted_address (only
+# the Google path set it). Backfill them from the matching street register entry.
+class BackfillGazetteerFormattedAddresses < ActiveRecord::Migration[8.1]
+  def up
+    streets_by_key = Street.where.not(street_key: nil).index_by(&:street_key)
+
+    gazetteer_locations = Location.where(formatted_address: nil).where("place_id LIKE 'gazetteer:%'")
+    gazetteer_locations.find_each do |location|
+      street = streets_by_key[location.place_id.delete_prefix('gazetteer:')]
+      next if street.nil?
+
+      # Backfill only; skip validations/callbacks so we don't touch updated_at.
+      location.update_columns(formatted_address: street.formatted_address) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    # No-op: cannot distinguish backfilled values from later edits.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -39,6 +39,7 @@ class LocationTest < ActiveSupport::TestCase
     assert_in_delta 53.58, location.latitude
     assert_in_delta 10.03, location.longitude
     assert_equal 'gazetteer:02;4;01;401;0401;T0010', location.place_id
+    assert_equal 'Testallee, 22305 Barmbek-Nord', location.formatted_address
     assert_equal @district, location.district
   end
 

--- a/test/models/street_test.rb
+++ b/test/models/street_test.rb
@@ -54,4 +54,17 @@ class StreetTest < ActiveSupport::TestCase
     @district.name = 'Umland'
     assert_empty Street.for('Testallee', @district).to_a
   end
+
+  test 'formatted_address composes name, postal code and stadtteil' do
+    assert_equal 'Testallee, 22305 Barmbek-Nord', streets(:testallee).formatted_address
+  end
+
+  test 'formatted_address degrades gracefully when locality parts are missing' do
+    street = streets(:testallee)
+    street.postal_code = nil
+    assert_equal 'Testallee, Barmbek-Nord', street.formatted_address
+
+    street.stadtteil = nil
+    assert_equal 'Testallee', street.formatted_address
+  end
 end


### PR DESCRIPTION
## Problem

After the street gazetteer was introduced, `Location.from_gazetteer` created records without a `formatted_address` — only the Google path (`from_google`) ever set that column, and there's no presence validation. Since the gazetteer is tried first and short-circuits, any street in the register resolved without an address.

`formatted_address` is rendered in page titles (`locations_controller.rb:12`), map marker popups (`_marker_popup.html.slim`), and tooltips, so nil produced broken strings like `"Bergedorfer Straße - "`.

## Fix

- **`Street#formatted_address`** — composes a street-level address from the register's own fields (`name`, `postal_code`, `stadtteil`), e.g. `"Testallee, 22305 Barmbek-Nord"`. Degrades gracefully when locality parts are missing. No Google round-trip.
- **`Location.from_gazetteer`** — now sets `formatted_address` from the matched street.
- **Backfill migration** — recomputes `formatted_address` for existing `gazetteer:*` locations with a nil value, matching each to its `Street` by `street_key` parsed from the `place_id`.

## Tests

Added coverage in `street_test.rb` (composition + graceful degradation) and `location_test.rb` (gazetteer path now populates the address). Full suite green: 156 runs, 504 assertions, 0 failures. Rubocop clean.