### PR TITLE
Speed up committee show page: cache agenda item word count

### DIFF
--- a/app/controllers/committees_controller.rb
+++ b/app/controllers/committees_controller.rb
@@ -10,12 +10,27 @@ class CommitteesController < ApplicationController
     @committee = @district.committees.find(params[:id])
     @timeline_series = committee_timeline_series(@committee)
     @recent_averages = @committee.recent_averages
-    @meetings = @committee.meetings.with_agenda.latest_first.includes(:agenda_items)
+    @meetings = @committee.meetings.with_agenda.latest_first.to_a
+    @meeting_stats = meeting_stats(@meetings)
     @memberships = ordered_memberships(@committee)
     @title = "#{@committee.name} - #{@committee.district.name}"
   end
 
   private
+
+  # Per-meeting figures for the meetings table, aggregated in a few grouped
+  # queries keyed by meeting id, so the view never touches the (heavy) agenda
+  # item text or fires a query per row.
+  def meeting_stats(meetings)
+    ids = meetings.map(&:id)
+    items = AgendaItem.where(meeting_id: ids)
+
+    {
+      agenda_item_counts: items.group(:meeting_id).count,
+      word_counts: items.group(:meeting_id).sum(:word_count),
+      logged_meeting_ids: items.logged.distinct.pluck(:meeting_id).to_set,
+    }
+  end
 
   # Two aligned monthly series for the combined committee chart: number of
   # documents and total minutes word count, both over the last 12 months. The
@@ -26,9 +41,9 @@ class CommitteesController < ApplicationController
                          .group_by_month('meetings.date').count
                          .transform_keys(&:to_date)
     words = committee.meetings.with_minutes.where(date: 12.months.ago..Time.zone.today)
-                     .includes(:agenda_items).to_a
-                     .group_by { |meeting| meeting.date.beginning_of_month }
-                     .transform_values { |monthly| monthly.sum(&:word_count) }
+                     .joins(:agenda_items)
+                     .group_by_month('meetings.date').sum('agenda_items.word_count')
+                     .transform_keys(&:to_date)
 
     [
       { name: 'Anzahl Drucksachen', data: documents },

--- a/app/models/agenda_item.rb
+++ b/app/models/agenda_item.rb
@@ -10,6 +10,7 @@
 #  number      :string
 #  result      :text
 #  title       :string
+#  word_count  :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  allris_id   :integer
@@ -38,6 +39,8 @@ class AgendaItem < ApplicationRecord
   scope :by_meeting, -> { joins(:meeting).includes(:meeting).merge(Meeting.latest_first) }
   scope :logged, -> { where.not(allris_id: nil) }
   scope :with_minutes, -> { where.not(minutes: nil) }
+
+  before_save :cache_word_count
   scope :incomplete, lambda {
     joins(:meeting).where.not(allris_id: nil)
                    .where('meetings.date <= ? AND meetings.date >= ?', 30.days.ago, 270.days.ago)
@@ -91,13 +94,6 @@ class AgendaItem < ApplicationRecord
     Nokogiri::HTML.parse(minutes).text.present? || Nokogiri::HTML.parse(result).text.present?
   end
 
-  # Number of words recorded for this agenda item (discussion + outcome), with
-  # HTML markup stripped. Used as the building block for the per-meeting
-  # "how much was discussed" metric.
-  def word_count
-    [minutes, result].sum { |text| strip_tags(text.to_s).split.size }
-  end
-
   def extract_result(html)
     clean_html(html.xpath("//div[preceding-sibling::a[@name='allrisAE']]")).presence ||
       clean_html(html.xpath("//div[preceding-sibling::a[@name='allrisBS']]")).presence
@@ -114,5 +110,18 @@ class AgendaItem < ApplicationRecord
     query = query.where('agenda_items.minutes ILIKE :term', term: "%#{term.downcase}%")
 
     query.order('meetings.date DESC')
+  end
+
+  private
+
+  def cache_word_count
+    self.word_count = computed_word_count
+  end
+
+  # Number of words recorded for this agenda item (discussion + outcome), with
+  # HTML markup stripped. Cached into the word_count column on save so the
+  # per-meeting "how much was discussed" metric can be aggregated in SQL.
+  def computed_word_count
+    [minutes, result].sum { |text| strip_tags(text.to_s).split.size }
   end
 end

--- a/app/models/committee.rb
+++ b/app/models/committee.rb
@@ -62,11 +62,12 @@ class Committee < ApplicationRecord
   # the SAME set of meetings; duration additionally skips any of them without a
   # recorded start/end time. Each value is nil when there is nothing to average.
   def recent_averages(limit = RECENT_MEETINGS_FOR_AVERAGE)
-    recent = meetings.with_minutes.latest_first.includes(:agenda_items).limit(limit).to_a
+    recent = meetings.with_minutes.latest_first.limit(limit).to_a
     timed = recent.select { |meeting| meeting.start_time && meeting.end_time }
+    word_counts = AgendaItem.where(meeting_id: recent.map(&:id)).group(:meeting_id).sum(:word_count)
 
     {
-      word_count: recent.any? ? (recent.sum(&:word_count).to_f / recent.size).round : nil,
+      word_count: recent.any? ? (word_counts.values.sum.to_f / recent.size).round : nil,
       duration: timed.any? ? (timed.sum(&:duration).to_f / timed.size).round : nil,
     }
   end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -162,9 +162,10 @@ class Meeting < ApplicationRecord
   end
 
   # Total number of words recorded across all agenda items of this meeting.
-  # A rough proxy for how much was discussed ("how much talking").
+  # A rough proxy for how much was discussed ("how much talking"). Reads the
+  # cached per-item word_count, so it sums in SQL rather than parsing HTML.
   def word_count
-    agenda_items.sum(&:word_count)
+    agenda_items.sum(:word_count)
   end
 
   def logged?

--- a/app/views/committees/show.html.slim
+++ b/app/views/committees/show.html.slim
@@ -36,19 +36,20 @@ h2.h1
             = link_to meeting_path(meeting) do
               = meeting.title.html_safe
           td.text-end
-            = meeting.agenda_items.size
+            = @meeting_stats[:agenda_item_counts].fetch(meeting.id, 0)
           td.text-end.text-nowrap
             - if meeting.start_time.present? && meeting.end_time.present?
               = "#{number_with_precision(meeting.duration.to_f / 3600, precision: 2)} h"
             - else
               | -
           td.text-end.text-nowrap
-            - if meeting.word_count.positive?
-              = "#{number_with_delimiter(meeting.word_count)} Wörter"
+            - word_count = @meeting_stats[:word_counts].fetch(meeting.id, 0)
+            - if word_count.positive?
+              = "#{number_with_delimiter(word_count)} Wörter"
             - else
               | -
           td.text-end.text-nowrap
-            - if meeting.logged?
+            - if @meeting_stats[:logged_meeting_ids].include?(meeting.id)
               => meeting_minutes_link(meeting)
             = allris_link meeting.allris_url
 

--- a/db/migrate/20260707160000_add_word_count_to_agenda_items.rb
+++ b/db/migrate/20260707160000_add_word_count_to_agenda_items.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Cache the HTML-stripped word count of each agenda item's minutes/result so the
+# committee page can aggregate "discussion volume" in SQL instead of running
+# Nokogiri strip_tags over every item on every request.
+class AddWordCountToAgendaItems < ActiveRecord::Migration[8.1]
+  def up
+    add_column :agenda_items, :word_count, :integer, default: 0, null: false
+
+    # Backfill existing rows with the same Ruby computation used on save, so the
+    # cached values match what the app has always displayed.
+    say_with_time 'Backfilling agenda_items.word_count' do
+      count = 0
+      AgendaItem.where.not(minutes: nil).or(AgendaItem.where.not(result: nil)).find_each do |item|
+        item.update_column(:word_count, item.send(:computed_word_count)) # rubocop:disable Rails/SkipsModelValidations
+        count += 1
+      end
+      count
+    end
+  end
+
+  def down
+    remove_column :agenda_items, :word_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -56,6 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_140000) do
     t.text "result"
     t.string "title"
     t.datetime "updated_at", null: false
+    t.integer "word_count", default: 0, null: false
     t.index "((setweight(to_tsvector('german'::regconfig, (title)::text), 'A'::\"char\") || setweight(to_tsvector('german'::regconfig, minutes), 'B'::\"char\")))", name: "agenda_items_expr_idx", using: :gin
     t.index ["document_id"], name: "index_agenda_items_on_document_id"
     t.index ["meeting_id"], name: "index_agenda_items_on_meeting_id"

--- a/test/models/agenda_item_test.rb
+++ b/test/models/agenda_item_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AgendaItemTest < ActiveSupport::TestCase
+  setup do
+    @meeting = meetings(:rega_ewi_oct)
+  end
+
+  test 'caches the HTML-stripped word count on save' do
+    item = @meeting.agenda_items.create!(minutes: '<p>Es wurde lange diskutiert</p>', result: 'Beschlossen')
+
+    assert_equal 5, item.word_count # 4 words of minutes + 1 of result, tags stripped
+  end
+
+  test 'recomputes the cached word count when the text changes' do
+    item = @meeting.agenda_items.create!(minutes: 'nur kurz')
+    assert_equal 2, item.word_count
+
+    item.update!(minutes: 'jetzt etwas mehr Text')
+
+    assert_equal 4, item.reload.word_count
+  end
+
+  test 'word count is zero without minutes or result' do
+    item = @meeting.agenda_items.create!(minutes: nil, result: nil)
+
+    assert_equal 0, item.word_count
+  end
+end


### PR DESCRIPTION
## Problem

The committee show page (e.g. `/hamburg-nord/committees/7`) is slow. Profiling a heavy committee (13 meetings, 421 agenda items) showed the request:

- Ran **Nokogiri `strip_tags` over every agenda item's `minutes`+`result` on every request** to compute word counts — ~222ms of pure CPU that grows with a committee's full history.
- Loaded all agenda items **including their heavy `minutes`/`result` text** (~119ms).
- Hit an **N+1** for per-meeting `logged?` (one query per meeting; not query-cached, since each `meeting_id` differs).

## Fix

Cache the word count per agenda item and aggregate in SQL.

- **`agenda_items.word_count`** column, computed from the item's own text via `before_save :cache_word_count` (the same Ruby `strip_tags` logic as before), backfilled in the migration.
- **`Meeting#word_count`** sums the cached column (`agenda_items.sum(:word_count)`) instead of parsing HTML.
- **`Committee#recent_averages`** and the **committee chart** aggregate word counts in SQL — no more loading agenda-item text.
- The **meetings table** reads per-meeting agenda counts, word sums and logged status from a few grouped queries (`meeting_stats`), so the view never touches agenda text or queries per row.

## Results (heaviest local committee)

| | before | after |
|---|---|---|
| table data path | ~364ms, 13+ queries | **48ms, 4 queries** |
| word-count computation | 222ms Nokogiri/request | 0 (SQL sum) |

Cached values match the previous Ruby computation **exactly** (0 mismatches over an 80-item sample).

## Backfill

The migration backfills existing rows inline (Nokogiri once per item, ~6ms/row); the `before_save` callback keeps new/changed items current thereafter. For the app's scale this one-time cost is acceptable.

## Notes
- The remaining repeated `districts` lookups on the page are identical within a request, so Rails' SQL query cache already serves them from memory — left as-is.
- The members-list `member.allris_url` N+1 is pre-existing and out of scope here.

## Tests
Adds `test/models/agenda_item_test.rb` (caches on save, recomputes on change, zero without text); existing meeting/committee/controller/job tests still pass.