### PR TITLE
Add Bezirkspolitik and Beteiligung subpages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,4 +14,8 @@ class PagesController < ApplicationController
   def transparency; end
 
   def mcp; end
+
+  def district_politics; end
+
+  def participation; end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -80,6 +80,8 @@ html lang='de'
         .float-end
           p
             = link_to 'Was soll das Ganze?', about_path(district: nil), class: 'px-1 text-reset'
+            => link_to 'Bezirkspolitik', district_politics_path(district: nil), class: 'px-1 text-reset'
+            => link_to 'Beteiligung', participation_path(district: nil), class: 'px-1 text-reset'
             => link_to 'Transparenz', transparency_path(district: nil), class: 'px-1 text-reset'
             => link_to 'MCP', mcp_path(district: nil), class: 'px-1 text-reset'
             => link_to 'Datenschutz', privacy_path(district: nil), class: 'px-1 text-reset'

--- a/app/views/pages/district_politics.html.slim
+++ b/app/views/pages/district_politics.html.slim
@@ -1,0 +1,123 @@
+h1.my-3 Bezirkspolitik
+
+p
+  | Was sind die Aufgaben der Bezirke, wie arbeitet die Bezirkspolitik und zu welchem Bezirk gehöre ich eigentlich?
+
+h2.h3 Zu welchem Bezirk gehöre ich?
+
+p
+  ' Fragen Sie im
+  => link_to 'Hamburger Geoportal', 'https://geoportal-hamburg.de/'
+  ' für Ihre Adresse ab, zu welchem Bezirk Sie gehören. Zusätzlich finden Sie dort auch Ihre Wahlbezirke für
+    verschiedene Wahlen.
+
+h2.h3 Wofür sind die Bezirke zuständig?
+
+p
+  ' Hamburg besteht aus sieben
+  => link_to 'Bezirken', 'https://www.hamburg.de/leben-in-hamburg/bezirke-hamburg'
+  ' (z. B. Hamburg-Mitte, Altona), die in Stadt- und Ortsteile unterteilt sind. Jeder Bezirk hat ein Bezirksamt,
+    das sich um die Aufgaben im Bezirk kümmert, darunter der Bau von Gebäuden und Wegen, die Pflege von Grünflächen,
+    um Wirtschaft, Sport, Stadteilkultur, Gesundheit und soziale Unterstützung. Um bezirksübergreifende Themen
+    kümmern sich der
+  => link_to 'Senat', 'https://www.hamburg.de/politik-und-verwaltung/senat'
+  ' (Landesregierung der Stadt Hamburg) und seine nachgeordneten Fachbehörden (z.B. Schulbehörde).
+
+p
+  ' Die Einwohner eines Bezirks wählen alle fünf Jahre eine Bezirksversammlung. Wählen können alle, die mindestens
+    16 Jahre alt sind und seit drei Monaten in Hamburg leben und die deutsche oder eine EU-Staatsbürgerschaft
+    besitzen. Die Bezirksversammlung berät das Bezirksamt, kann bindende Beschlüsse fassen (z.B. Bau eines
+    Spielplatzes) und kontrolliert die Verwaltung. Gesetze beschließt nur die
+  => link_to 'Hamburgische Bürgerschaft', 'https://www.hamburgische-buergerschaft.de/'
+  ' (Landesparlament) oder die Hamburgerinnen und Hamburger per
+  = link_to 'Volksentscheid', 'https://www.hamburgische-buergerschaft.de/beteiligung/volksgesetzgebung'
+  '.
+
+h2.h3 So arbeitet die Bezirkspolitik
+
+h3.h5 Bezirksversammlung
+
+p
+  | Die Bezirksversammlungen kontrollieren die Arbeit der Bezirksämter und können teilweise auch mitentscheiden,
+    wofür Geld ausgegeben wird. Zusätzlich wählt die Bezirksversammlung die Bezirksamtsleiterinnen und -leiter,
+    die der Senat anschließend ernennt. Darüber hinaus kontrollieren sie die Bezirksämter bei ihrer Arbeit, d.h.
+    sie lassen sich über Pläne und Fortschritte informieren und können dazu Beschlüsse treffen. Die
+    Bezirksversammlungen sprechen auch Empfehlungen an Fachbehörden aus, wenn eine Angelegenheit den Bezirk
+    betrifft, aber eine Fachbehörde zuständig ist (z.B. zu einem Fahrradweg an einer Hauptstraße).
+
+h3.h5 Ausschüsse
+
+p
+  | Die meisten Beschlüsse der Bezirksversammlung werden in Ausschüssen vorbereitet, die mit Mitgliedern der
+    Bezirksversammlung besetzt sind. Ausschüsse sind jeweils für einen bestimmten Themenbereich zuständig und
+    können Informationen oder Unterlagen vom Bezirksamt einfordern (Akteneinsicht) und ihre Mitglieder können
+    Anfragen an ihre Bezirksamtsleitung sowie an die für das jeweilige Thema zuständige Fachbehörde stellen.
+
+h3.h5 Fachausschüsse
+
+p
+  | Die Ausschüsse sind je nach Bezirk individuell zugeschnitten, hier das Beispiel Hamburg-Nord:
+
+ul
+  li Hauptausschuss (themenübergreifend, Koordination der Ausschüsse)
+  li Ausschuss Bildung, Kultur und Sport
+  li Ausschuss für Klimaschutz, Umwelt und Mobilität
+  li Ausschuss für Wirtschaft, Arbeit und Digitalisierung
+  li Ausschuss für Seniorinnen und Senioren, Integration, Inklusion, Gesundheit und Katastrophenschutz
+  li Haushaltsausschuss
+  li Jugendhilfeausschuss
+  li Stadtentwicklungsausschuss
+  li Vergabeausschuss
+
+p
+  | Darüber hinaus gibt es oft Regionalausschüsse für mehrere Stadtteile und zusätzlich Unterausschüsse für
+    Bauangelegenheiten. Die Zuschnitte der Ausschüsse mit ihren Themen unterscheidet sich zwischen den sieben
+    Hamburger Bezirken, da jede Bezirksversammlung selbst über die Aufteilung entscheiden kann.
+
+p
+  | Bis auf den Hauptausschuss sind die Ausschüsse selbst in der Regel nicht beschlussfähig sondern sprechen
+    nur sogenannte Beschlussempfehlungen aus. Diese werden dann von der Bezirksversammlung oder dem Hauptausschuss
+    bestätigt.
+
+h2.h3 Von der Vorlage zum Beschluss
+
+p
+  | Die Vorgänge (Mitteilungen und Entscheidungen) der Bezirksversammlungen und der Ausschüsse werden in
+    sogenannten Vorlagen (auch Drucksache genannt) vorbereitet. Jede Vorlage erhält eine Nummer, über die der
+    Verlauf der Entscheidungsfindung nachvollziehbar ist. Die meisten Vorlagen sind öffentlich und damit frei
+    zugänglich. Auf BV-HH wird darauf verlinkt. Folgende Arten von Vorlagen werden genutzt:
+
+ul
+  li Anträge einer oder mehrere Parteien
+  li Beschlussvorlagen, z.B. vom Bezirksamt
+  li Beschlussempfehlungen der Ausschüsse für Hauptausschuss oder Bezirksversammlung
+  li Mitteilungsvorlagen des Vorsitzes, z.B. Bürgereingaben
+  li Anfragen aus der Politik an Bezirksämter und / oder Fachbehörden
+  li Mitteilungen des Bezirksamts (nachrichtlich)
+  li Vorlagen des Bezirksamts mit Beschlussvorschlag
+
+p
+  | Anträge und Vorlagen können zur Kenntnis genommen, abgelehnt, mit oder ohne Änderung angenommen werden. Sie
+    können auch an einen anderen Ausschuss zur Beratung überwiesen werden.
+
+h2.h3 Bezirkspolitik im Internet: Die Ratsinformationssysteme
+
+p
+  | Jeder Bezirk hat sein eigenes Ratsinformationssystem mit allen Sitzungsterminen, Tagesordnungen und
+    (öffentlichen) Drucksachen. Nichtöffentliche Drucksachen sind nur für eingeloggte Nutzer (Abgeordnete oder Ausschussmitglieder) einsehbar,
+    der allergrößte Teil der Drucksachen ist aber öffentlich zugänglich.
+    BV-HH fasst diese Infos für alle Bezirke zusammen und verlinkt direkt in die Ratsinformationssysteme.
+
+.table-responsive
+  table.table
+    thead
+      th Bezirk
+      th Ratsinformationssystem
+
+    tbody
+      - District.all.by_order.each do |district|
+        tr
+          td= district.name
+          - allris_url = "#{district.allris_base_url}/bi/allris.net.asp"
+          td= link_to allris_url, allris_url, target: '_blank'
+

--- a/app/views/pages/home.html.slim
+++ b/app/views/pages/home.html.slim
@@ -4,6 +4,18 @@
     p.lead
       | BV-HH.de bietet einen übersichtlichen und schnellen Zugang zu allen öffentlichen Dokumenten der Hamburger Bezirksversammlungen.
         Bitte nutzen Sie die Suche, den Kalender oder wählen Sie unten einen der Hamburger Bezirke aus!
+    p
+      | Politik beschränkt sich nicht auf Wahlen. Bereichern Sie die Bezirkspolitik mit Ihrer Beteiligung. Dazu gibt es viele
+        Möglichkeiten: Von der Beteiligung an öffentlichen Sitzungen, über Bürgereingaben, als Beisitzerin oder Beisitzer in
+        Bezirksausschüssen bis hin zur Kandidatin oder Kandidat für die Bezirksversammlung, können Sie Bezirkspolitik aktiv
+        mitgestalten und sich einbringen. Die dafür nötigen Informationen sind nicht immer leicht zu finden, BV-HH.de versucht
+        hierzu einen Einstieg und eine Informationssammlung zu bieten.
+    p
+      ' Weitere Informationen zur Bezirkspolitik und Beteiligungsmöglichkeiten finden Sie auf den Unterseiten
+      = link_to 'Bezirkspolitik', district_politics_path
+      ' und
+      = link_to 'Beteiligung', participation_path
+      '.
     hr.my-4
     p
       strong

--- a/app/views/pages/participation.html.slim
+++ b/app/views/pages/participation.html.slim
@@ -1,0 +1,288 @@
+h1.my-3 Beteiligung
+
+p
+  | Wie kann ich mich in die politischen Prozesse in den Bezirken einbringen und welche Fördermöglichkeiten für Initiativen bestehen vor Ort?
+
+h2.h3 Sich einbringen
+
+p
+  | Es gibt eine Reihe von Möglichkeiten, in den Bezirken Anregungen einzubringen oder sich an Entscheidungen zu
+    beteiligen. Hier finden Sie die Beteiligungsmöglichkeiten und Kontakte für den jeweiligen Bezirk.
+
+h3.h5 Eingaben
+
+p
+  | Mit Eingaben können Sie sich mit Anregungen, Bitten oder Beschwerden direkt an die Bezirksversammlungen
+    wenden, den Kontakt und weitere Informationen hierzu finden Sie auf folgender Seite Ihres Bezirks:
+
+.table-responsive
+  table.table
+    thead
+      th Bezirk
+      th Link zur Webseite
+      th Mail
+      th Postanschrift
+
+    tbody
+      tr
+        td Altona
+        td= link_to 'Online-Eingabe', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/altona/bezirksversammlung/eingaben-55492'
+        td= link_to 'bezirksversammlung@altona.hamburg.de', 'mailto:bezirksversammlung@altona.hamburg.de'
+        td Bezirksversammlung Altona, Platz der Republik 1, 22765 Hamburg
+      tr
+        td Bergedorf
+        td= link_to 'Online-Eingabe', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bergedorf/buergerservice/online-eingabe-56256'
+        td= link_to 'eingaben@bergedorf.hamburg.de', 'mailto:eingaben@bergedorf.hamburg.de'
+        td Geschäftsstelle der Bezirksversammlung Bergedorf, Wentorfer Straße 38, 21029 Hamburg
+      tr
+        td Eimsbüttel
+        td= link_to 'Online-Eingabe', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bezirksamt-eimsbuettel/bezirksversammlung/online-eingaben-61890'
+        td= link_to 'bezirksversammlung@eimsbuettel.hamburg.de', 'mailto:bezirksversammlung@eimsbuettel.hamburg.de'
+        td Geschäftsstelle der Bezirksversammlung Eimsbüttel, Grindelberg 62–66, 20144 Hamburg
+      tr
+        td Hamburg-Mitte
+        td= link_to 'Online-Eingabe', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/mitte/bezirksversammlung/eingaben-online-67142'
+        td= link_to 'bezirksversammlung@hamburg-mitte.hamburg.de', 'mailto:bezirksversammlung@hamburg-mitte.hamburg.de'
+        td Geschäftsstelle der Bezirksversammlung Hamburg-Mitte, Caffamacherreihe 1–3, 20355 Hamburg
+      tr
+        td Harburg
+        td= link_to 'Online-Eingaben Harburg', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/harburg/bezirksversammlung/online-eingaben-798524'
+        td= link_to 'bezirksversammlung@harburg.hamburg.de', 'mailto:bezirksversammlung@harburg.hamburg.de'
+        td Geschäftsstelle der Bezirksversammlung Harburg, Harburger Rathausplatz 1, 21073 Hamburg
+      tr
+        td Hamburg-Nord
+        td= link_to 'Online-Eingabe', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/hamburg-nord/eingaben-bezirksversammlung-und-ausschuesse-71374'
+        td= link_to 'bezirksversammlung@hamburg-nord.hamburg.de', 'mailto:bezirksversammlung@hamburg-nord.hamburg.de'
+        td Geschäftsstelle der Bezirksversammlung Hamburg-Nord, Kümmellstraße 7, 20249 Hamburg
+      tr
+        td Wandsbek
+        td= link_to 'Online-Eingabe', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/wandsbek/bezirksversammlung-wandsbek/eingaben-439122'
+        td= link_to 'bezirksversammlung@wandsbek.hamburg.de', 'mailto:bezirksversammlung@wandsbek.hamburg.de'
+        td Geschäftsstelle der Bezirksversammlung Wandsbek, Schloßstraße 60, 22041 Hamburg
+
+h3.h5 Themen, um die sich andere Stellen kümmern
+
+p
+  ' Für Müll und Verschmutzung im öffentlichen Raum hat die Stadtreinigung die Hotline "Saubere Stadt" mit der
+    Telefonnummer 25761111 und ein
+  => link_to 'Kontaktformular "Saubere Stadt"', 'https://www.stadtreinigung.hamburg/kontakt/kontaktformular.html?kontakt=Verschmutzungshotline'
+  ' im Internet eingerichtet und eine App bereitgestellt.
+
+p
+  ' Schäden oder Einschränkungen an der öffentlichen Infrastruktur (Straßen, Laternen, Bänken, Schildern usw.)
+    können Sie online über den
+  => link_to '"Melde-Michel"', 'https://www.hamburg.de/melde-michel/'
+  ' mitteilen.
+
+h3.h5 Öffentliche Sitzungen
+
+p
+  | Die meisten Sitzungen der Bezirksversammlungen und deren Ausschüsse sind öffentlich, d.h. alle Interessierten
+    können die Sitzungen besuchen und zu Beginn Fragen zu kommunalpolitischen Themen stellen. Die Fragen sollten
+    kurz und sachbezogen sein und können dem vorsitzenden Mitglied vor der Fragestunde schriftlich oder während
+    der Fragestunde mündlich gestellt werden. Nach der Antwort kann eine Nachfrage gestellt werden.
+
+h3.h5 Mitgliedschaft in Beiräten
+
+p
+  | Zusätzlich zu den Ausschüssen gibt es in den Bezirken Beiräte, die die Ausschüsse zu bestimmten Themen beraten
+    und die aus separat gewählten (nicht politischen) Mitgliedern bestehen oder einfach offen für alle
+    Interessierten sind. Sie bringen die Perspektiven von Hamburgerinnen und Hamburgern ein, die ansonsten häufig
+    unterrepräsentiert sind, wie z.B. Seniorinnen und Senioren, Jugendliche oder wegen ausländischer
+    Staatsbürgerschaft nicht Wahlberechtigte, oder sorgen für eine stärkere Beteiligung vor Ort (z.B.
+    Stadtteilräte).
+
+p
+  | Diese Beiräte gibt es in den Bezirken. Die Links führen zu Webseiten mit Infos zum Mitmachen:
+
+.table-responsive
+  table.table
+    thead
+      th Bezirk
+      th Beiräte
+      th Link zur Webseite
+      th Kontakt
+
+    tbody
+      tr
+        td Altona
+        td
+          | Stadtteilrat Altona-Altstadt
+          br
+          | Stadtteilrat Borner Runde
+          br
+          | Stadtteilbeirat Luruper Forum
+          br
+          | Stadtteilbeirat Sternschanze
+        td
+          = link_to 'Stadtteilrat Altona-Altstadt', 'https://stadtteilbeiraete-hamburg.de/stadtteilbeirat/stadtteilrat-altona-altstadt/'
+          br
+          = link_to 'Stadtteilrat Borner Runde', 'https://stadtteilbeiraete-hamburg.de/stadtteilbeirat/borner-runde/'
+          br
+          = link_to 'Stadtteilbeirat Luruper Forum', 'https://stadtteilbeiraete-hamburg.de/stadtteilbeirat/stadtteilbeirat-luruper-forum'
+          br
+          = link_to 'Stadtteilbeirat Sternschanze', 'https://stadtteilbeiraete-hamburg.de/stadtteilbeirat/stadtteilbeirat-sternschanze'
+        td
+          | info@stadtteilrat.de, c/o HausDrei, Hospitalstraße 107, 22767 Hamburg
+          br
+          | Bürgerhaus Bornheide, Bornheide 76E, 22549 Hamburg
+          br
+          | 040 524 732 66, 0162 205 51 80, info@borner-runde.de
+          br
+          | Stadtteil-Kultur-Büro im Stadtteilhaus Lurup, Böverstland 38, 22547 Hamburg, 040 280 55 553, info@unser-lurup.de
+          br
+          | Stadtteilbeirat Sternschanze, c/o Standpunkt.Schanze e.V., Postfach 306247, 20328 Hamburg, 040 60942027, info@standpunktschanze.de
+      tr
+        td
+        td Weitere Stadtteil- und Quartiersbeiräte (Übersicht)
+        td= link_to 'hamburg.de – Bezirksversammlung Altona', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/altona/bezirksversammlung'
+        td Kontakte über die Geschäftsstelle der Bezirksversammlung Altona
+      tr
+        td Bergedorf
+        td Seniorenbeirat Bergedorf
+        td= link_to 'hamburg.de – Bergedorf', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bergedorf'
+        td Über die Bezirksversammlung Bergedorf erreichbar
+      tr
+        td Eimsbüttel
+        td Inklusionsbeirat Eimsbüttel
+        td= link_to 'hamburg.de – Bezirksversammlung Eimsbüttel', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bezirksamt-eimsbuettel/bezirksversammlung'
+        td Hans-Jürgen Rehder (Ansprechperson)
+      tr
+        td
+        td Bezirks-Seniorenbeirat (BSB) Eimsbüttel
+        td= link_to 'hamburg.de – Bezirksversammlung Eimsbüttel', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bezirksamt-eimsbuettel/bezirksversammlung'
+        td Über die Bezirksversammlung Eimsbüttel erreichbar
+      tr
+        td Hamburg-Mitte
+        td Stadtteil- und Quartiersbeiräte (Übersicht)
+        td= link_to 'hamburg.de – Bezirksamt Hamburg-Mitte – Beiräte', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/mitte/bezirksamt'
+        td Kontaktinformationen auf den verlinkten Seiten der jeweiligen Beiräte
+      tr
+        td Harburg
+        td Seniorenbeirat
+        td= link_to 'hamburg.de – Seniorenbeirat Harburg', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/harburg/themen/familie-jugend-senior-innen/senioren/seniorenbeirat-63896'
+        td Über die Geschäftsstelle der Bezirksversammlung Harburg, Harburger Rathausplatz 1, 21073 Hamburg
+      tr
+        td
+        td
+          | Harburger Integrationsrat (HIR)
+          br
+          | Stadtteilbeirat Neuwiedenthal
+        td
+          = link_to 'Harburger Integrationsrat', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/harburg/themen/soziales/integration/harburger-integrationsrat-64780'
+          br
+          = link_to 'Stadtteilbeirat Neuwiedenthal', 'https://stadtteilbeiraete-hamburg.de/stadtteilbeirat/stadtteilbeirat-neuwiedenthal/'
+        td
+          | -
+      tr
+        td Hamburg-Nord
+        td Regionalausschüsse (Langenhorn-Fuhlsbüttel-Ohlsdorf-Alsterdorf-Groß Borstel, Barmbek-Uhlenhorst-Dulsberg, Eppendorf-Winterhude)
+        td= link_to 'hamburg.de – Bezirksamt Hamburg-Nord', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/hamburg-nord'
+        td Über die Bezirksversammlung Hamburg-Nord, Kümmellstraße 7, 20249 Hamburg
+      tr
+        td Wandsbek
+        td Stadtteil- und Quartiersbeiräte (Übersicht)
+        td= link_to 'hamburg.de – Bezirksamt Wandsbek – Beiräte', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/wandsbek'
+        td Kontakte in der Broschüre „Zuhause in Wandsbek“ oder über die Bezirksversammlung Wandsbek
+
+h3.h5.mt-4 Weitere Beteiligungsmöglichkeiten
+
+p.mt-3
+  strong Beteiligung.Hamburg – die Online-Beteiligung in Hamburg
+p
+  ' Auf
+  => link_to 'Hamburgs Beteiligungsplattform', 'https://beteiligung.hamburg/navigator/'
+  ' werden regelmäßig Online-Beteiligungen für unterschiedlichste Themen veröffentlicht. Dort kann nach Bezirken
+    gefiltert werden.
+
+p
+  strong Bürgerbegehren und Bürgerentscheide
+p
+  | Bürgerbegehren und anschließende Bürgerentscheide sind auch auf Bezirksebene möglich. Damit können
+    wahlberechtigte Einwohnerinnen und Einwohner im Zuständigkeitsbereich der Bezirksversammlung direkt
+    Entscheidungen bewirken. Das Bürgerbegehren ist der erste Schritt, es ist ein Antrag auf Durchführung eines
+    Bürgerentscheides. Dafür müssen innerhalb von sechs Monaten je nach Größe des Bezirks Unterschriften von
+    mindestens 2% bis 3% der wahlberechtigten Einwohnerinnen und Einwohner des Bezirks gesammelt werden.
+    Anschließend kann die Bezirksversammlung dem Anliegen direkt zustimmen oder einen Bürgerentscheid
+    durchführen. Das Bürgerbegehren muss schriftlich von drei Personen beim Bezirksamt angemeldet werden.
+p
+  ' Detaillierte Infos und Beratung zum Vorgehen hat der Verein Mehr Demokratie e.V.
+  = link_to 'zusammengestellt', 'https://hh.mehr-demokratie.de/themen/direkte-demokratie/buergerbegehren'
+  '.
+
+p
+  strong Direktes Gespräch
+p
+  | Die Möglichkeiten, direkt mit Abgeordneten der Bezirksversammlungen ins Gespräch zu kommen, sind vielfältig
+    und unterscheiden sich in den Bezirken und Stadtteilen. Viele Parteien bieten in den Bezirken regelmäßig
+    Bürgersprechstunden an, informieren oder diskutieren bei Veranstaltungen zu bestimmten Themen. Darüber
+    hinaus kann man im Vorfeld von öffentlichen Sitzungen ggf. mit "seinen" Abgeordneten ins Gespräch kommen.
+
+h2.h3 Förderung von Initiativen und Projekten
+
+p
+  | Initiativen und Projekte für ein gutes Miteinander und Angebote in den Stadtteilen können bei den Bezirken
+    Zuschüsse beantragen:
+
+ul
+  li
+    strong> Bezirkliche Sondermittel:
+    ' Für Projekte im Bezirk, die die Bezirksversammlung als förderungswürdig betrachtet.
+  li
+    strong> Förderfonds „Vertrag für Hamburg“:
+    ' Für Projekte zur Steigerung der Attraktivität, Lebensqualität und Werthaltigkeit des Bezirks.
+  li
+    strong> Quartiersfonds:
+    ' Jeder Bezirk hat einen sogenannten „Quartiersfonds“ zur Unterstützung der Stadtteilarbeit und
+      Stadtteilentwicklung, insbesondere zur Stärkung der sozialen Infrastruktur.
+
+h3.h5 Bezirk Altona
+
+p
+  ' Übersicht zu allen Fördermöglichkeiten im Bezirk:
+  = link_to 'hamburg.de – Finanzplanung Altona', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/altona/themen/soziales/finanzplanung-50954'
+
+h3.h5 Bezirk Bergedorf
+
+p
+  ' Antragsberechtigt sind Vereine, Initiativen und Gruppen, aber auch Einzelpersonen. Finanziert werden
+    vorrangig gemeinnützige Maßnahmen sowie Projekte im und für den Stadtteil Bergedorf:
+  = link_to 'hamburg.de – Sondermittel Bergedorf', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bergedorf/buergerservice/sondermittel-56580'
+
+h3.h5 Bezirk Eimsbüttel
+
+p
+  ' Vergabe von Sondermitteln der Bezirksversammlung Eimsbüttel zur Förderung von Initiativen im Bezirk:
+  = link_to 'hamburg.de – Sondermittel Eimsbüttel', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/bezirksamt-eimsbuettel/bezirksversammlung/sondermittel-der-bezirksversammlung-58382'
+
+h3.h5 Bezirk Harburg
+
+p
+  ' Fördermittel für Harburger Initiativen, Vereine, Institutionen und gemeinnützige Einrichtungen
+    (Sondermittel, Vertrag für Hamburg und Quartiersfonds):
+  = link_to 'hamburg.de – Fördermittel Harburg', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/harburg/bezirksversammlung/foerdermittel-64272'
+
+h3.h5 Bezirk Mitte
+
+p
+  ' Bezirkliche Sondermittel insbesondere für gemeinnützige Einrichtungen des Bezirks Hamburg-Mitte, um
+    Maßnahmen und Projekte finanzieren zu können:
+  = link_to 'hamburg.de – Sondermittel Mitte', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/mitte/bezirksversammlung/sondermittel-67160'
+
+p
+  ' Quartiersfonds zur Unterstützung von Einrichtungen, Projekten und Strukturen im Bezirk, die wichtig für die
+    Stadtteile sind:
+  = link_to 'hamburg.de – Quartiersfonds Mitte', 'http://www.hamburg.de/politik-und-verwaltung/bezirke/mitte/themen/soziales/quartiersfonds-67878'
+
+h3.h5 Bezirk Nord
+
+p
+  ' Unterstützung von Vorhaben (Projekte/Maßnahmen) der Initiativen und Vereine im Bezirk:
+  = link_to 'hamburg.de – Sondermittel Hamburg-Nord', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/hamburg-nord/hinweise-fuer-die-beantragung-von-sondermitteln-fuer-vorhaben-im-bezirk-71398'
+
+h3.h5 Bezirk Wandsbek
+
+p
+  ' Förderung von Projekten für Wandsbeker Bürgerinnen und Bürger. Förderzwecke können die Durchführung von
+    sozialen und gemeinnützigen Vorhaben, Beschaffungen oder Baumaßnahmen im Bezirk sein:
+  = link_to 'hamburg.de – Finanzabwicklung Wandsbek', 'https://www.hamburg.de/politik-und-verwaltung/bezirke/wandsbek/themen/freizeit-und-kultur/finanzabwicklung-84750'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   get '/privacy' => 'pages#privacy', as: :privacy
   get '/transparency' => 'pages#transparency', as: :transparency
   get '/mcp' => 'pages#mcp', as: :mcp
+  get '/district-politics' => 'pages#district_politics', as: :district_politics
+  get '/participation' => 'pages#participation', as: :participation
 
   get '/not_found' => 'errors#not_found', as: :foo
   get '/404' => 'errors#not_found', as: :not_found

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -8,7 +8,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  %i[imprint privacy about transparency mcp].each do |action|
+  %i[imprint privacy about transparency mcp district_politics participation].each do |action|
     test "GET #{action}" do
       get send(:"#{action}_path")
       assert_response :success


### PR DESCRIPTION
## Summary
- New static pages `/district-politics` (Bezirkspolitik) and `/participation` (Beteiligung), following the existing `pages#about`-style pattern
- Home page intro extended with links to both, footer gains matching links
- Bezirkspolitik page's Ratsinformationssysteme section now lists every district with a link to its ALLRIS front page (built from `District#allris_base_url`)
- Content sourced from an info-collection doc on district politics & participation in Hamburg

## Test plan
- [x] `bundle exec rails test` — 178 runs, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] Manually rendered both pages and the footer to check links/spacing